### PR TITLE
Register Object3d instances with in-engine editor for several GameObjects

### DIFF
--- a/project/application/GameObject/Door/Door.cpp
+++ b/project/application/GameObject/Door/Door.cpp
@@ -86,6 +86,7 @@ void Door::Update()
 void Door::Initialize()
 {
     obj_->Initialize();
+    obj_->RegisterEditor("Door");
     autoLockSystem_->Initialize();
 
     isSendLockMessage_ = false;

--- a/project/application/GameObject/Edamame/Edamame.cpp
+++ b/project/application/GameObject/Edamame/Edamame.cpp
@@ -38,6 +38,7 @@ void Edamame::Initialize()
     };
 
     obj_->Initialize();
+    obj_->RegisterEditor("Edamame");
     localAABB_ = { .min = { -0.25f,-0.25f,-0.25f},.max = {0.25f,0.25f,0.25f} };
 
     //枝豆知識

--- a/project/application/GameObject/Flashlight/Flashlight.cpp
+++ b/project/application/GameObject/Flashlight/Flashlight.cpp
@@ -102,6 +102,7 @@ void Flashlight::Initialize()
     isSendGetLightMessage_ = false;
     isRayHit_ = false;
     obj_->Initialize();
+    obj_->RegisterEditor("Flashlight");
     transform_.translate = { 4.0f,0.1f,5.0f };
     transform_.rotate = { 0.0f,0.0f,0.0f };
     transform_.scale = { 1.0f,1.0f,1.0f };

--- a/project/application/GameObject/Key/Key.cpp
+++ b/project/application/GameObject/Key/Key.cpp
@@ -35,6 +35,7 @@ void Key::Initialize()
     };
     velocity_ = { 0.0f };
     obj_->Initialize();
+    obj_->RegisterEditor("Key");
     isRayHit_ = false;
     isLockerHit_ = false;
 

--- a/project/application/GameObject/PC/PC.cpp
+++ b/project/application/GameObject/PC/PC.cpp
@@ -86,6 +86,7 @@ void PC::Update()
 void PC::Initialize() {
 	isRayHit_ = false;
 	obj_->Initialize();
+	obj_->RegisterEditor("PC");
 	obj_->SetOutlineColor(kRayHitOutlineColor);
 	obj_->SetOutlineWidth(kRayHitOutlineWidth);
 

--- a/project/application/GameObject/Player/Player.cpp
+++ b/project/application/GameObject/Player/Player.cpp
@@ -116,6 +116,7 @@ void Player::Initialize() {
 
     // 体の初期化
     bodyObj_->Initialize();
+    bodyObj_->RegisterEditor("Player");
     bodyObj_->SetTransform(transform_);
 
     // 体にモデル挿入

--- a/project/application/GameObject/TimeCard/TimeCard.cpp
+++ b/project/application/GameObject/TimeCard/TimeCard.cpp
@@ -17,6 +17,7 @@ TimeCard::TimeCard()
 void TimeCard::Initialize()
 {
     modelObj_->Initialize();
+    modelObj_->RegisterEditor("TimeCard");
     transform_ = {
      .scale = {1.0f,1.0f,1.0f},
      .rotate = {0.0f,Function::kPi,0.0f},

--- a/project/application/GameObject/TimeCard/TimeCardRack.cpp
+++ b/project/application/GameObject/TimeCard/TimeCardRack.cpp
@@ -17,6 +17,7 @@ TimeCardRack::TimeCardRack()
 void TimeCardRack::Initialize()
 {
     modelObj_->Initialize();
+    modelObj_->RegisterEditor("TimeCardRack");
     transform_ = {
     .scale = {1.0f,1.0f,1.0f},
     .rotate = {0.0f,Function::kPi,0.0f},

--- a/project/application/GameObject/TimeCard/TimeCardWatch.cpp
+++ b/project/application/GameObject/TimeCard/TimeCardWatch.cpp
@@ -18,6 +18,7 @@ TimeCardWatch::TimeCardWatch()
 void TimeCardWatch::Initialize()
 {
     modelObj_->Initialize();
+    modelObj_->RegisterEditor("TimeCardWatch");
     transform_ = { .scale = {1.0f,1.0f,1.0f},.rotate = {0.0f,0.0f,0.0f},.translate = {0.0f,0.04f,0.0f} };
 }
 

--- a/project/application/GameObject/VendingMac/VendingMac.cpp
+++ b/project/application/GameObject/VendingMac/VendingMac.cpp
@@ -67,6 +67,7 @@ void VendingMac::Initialize() {
 	isRayHit_ = false;
 	interactRequested_ = false;
 	obj_->Initialize();
+	obj_->RegisterEditor("VendingMac");
 	drink_->Initialize();
 	SEManager::SoundPlay(SEManager::NOISE, true);
 	obj_->SetOutlineColor(kRayHitOutlineColor);


### PR DESCRIPTION
### Motivation
- Allow various GameObject instances to be visible and editable in the in-engine editor by registering their `Object3d` wrappers during initialization.

### Description
- Added `obj_->RegisterEditor("Door")` in `Door::Initialize()` and analogous `RegisterEditor` calls for `Edamame`, `Flashlight`, `Key`, `PC`, `VendingMac`, `TimeCard`, `TimeCardRack`, and `TimeCardWatch` in their `Initialize()` functions. 
- Registered `bodyObj_` for `Player` via `bodyObj_->RegisterEditor("Player")` to expose the player body object to the editor.
- These edits only add editor registration calls and do not change runtime logic, animation setup, or rendering/outlines.

### Testing
- Built the project after the changes and the build completed successfully.
- Ran the automated test suite and it passed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e712a36668832abfd6ad1eca60d485)