### PR TITLE
Register editor names for Mirror/Shadow stage primitives

### DIFF
--- a/project/application/GameObject/TestField/TestField.cpp
+++ b/project/application/GameObject/TestField/TestField.cpp
@@ -15,6 +15,7 @@ void TestField::Initialize()
 {
     transform_ = { .scale = {28.0f,0.01f,50.0f},.rotate = {0.0f,0.0f,0.0f},.translate = {0.0f,-0.01f,0.0f} };
     box_->Initialize(Primitive::Box, "Resources/TD3_3102/2d/floor.png");
+    box_->RegisterEditor("TestField");
     box_->SetTransform(transform_);
     box_->SetColor({ 1.0f,1.0f,1.0f,1.0f });
 }

--- a/project/application/GameObject/Wall/Wall.cpp
+++ b/project/application/GameObject/Wall/Wall.cpp
@@ -46,6 +46,7 @@ void Wall::Update()
 void Wall::Initialize()
 {
     primitive_->Initialize(Primitive::Box, "Resources/TD3_3102/2d/wall.png");
+    primitive_->RegisterEditor("Wall");
 }
 
 void Wall::Draw()

--- a/project/application/GameObject/Wall/WallManager.cpp
+++ b/project/application/GameObject/Wall/WallManager.cpp
@@ -59,6 +59,7 @@ void WallManager::Initialize()
 {
     room1_->Initialize();
     plane_->Initialize(Primitive::Plane, "Resources/TD3_3102/2d/out.jpg");
+    plane_->RegisterEditor("WallWindowPlane");
 
 
     // 壁の初期化

--- a/project/application/GameObject/Wall/WallManager2.cpp
+++ b/project/application/GameObject/Wall/WallManager2.cpp
@@ -46,6 +46,7 @@ void WallManager2::Initialize()
 {
     room1_->Initialize();
     plane_->Initialize(Primitive::Plane, "Resources/TD3_3102/2d/out.jpg");
+    plane_->RegisterEditor("Wall2WindowPlane");
 
     // 壁の初期化
     for (auto& wall : walls_) {


### PR DESCRIPTION
### Motivation
- Mirror/Shadow stage primitives (floor, wall, window planes) were not registered with the editor hierarchy like Object3d instances, making them harder to find and edit in the editor UI; this change registers those primitives so they appear with meaningful names.

### Description
- Add `box_->RegisterEditor("TestField")` in `project/application/GameObject/TestField/TestField.cpp` to register the floor primitive as `TestField`.
- Add `primitive_->RegisterEditor("Wall")` in `project/application/GameObject/Wall/Wall.cpp` and register window-plane primitives with `plane_->RegisterEditor("WallWindowPlane")` and `plane_->RegisterEditor("Wall2WindowPlane")` in `project/application/GameObject/Wall/WallManager.cpp` and `project/application/GameObject/Wall/WallManager2.cpp` respectively.

### Testing
- Verified the workspace diff shows the four files updated and the `RegisterEditor` calls are present in each file.
- No full build or runtime tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e71dc6857c832a80c7577e8526d272)