### PR TITLE
Add vector-based editor registration for Object3d and Primitive

### DIFF
--- a/project/Engine/Texture/Mesh/Object3d/Object3d.cpp
+++ b/project/Engine/Texture/Mesh/Object3d/Object3d.cpp
@@ -11,6 +11,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cmath>
+#include <string>
 
 Object3d::~Object3d() { UnregisterFromEditor(); }
 
@@ -45,6 +46,14 @@ void Object3d::RegisterEditor(const std::string& registrationName) {
 		Hierarchy::GetInstance()->AddRegisterObject(this, registrationName);
 	}
 	RegisterToEditor();
+}
+void Object3d::RegisterEditors(const std::vector<Object3d*>& objects, const std::string& registrationNamePrefix) {
+	for (size_t i = 0; i < objects.size(); ++i) {
+		if (!objects[i]) {
+			continue;
+		}
+		objects[i]->RegisterEditor(registrationNamePrefix + std::to_string(i));
+	}
 }
 void Object3d::RegisterToEditor(const std::string& saveFileName, const std::string& registrationName) {
 	if (isEditorRegistered_) {

--- a/project/Engine/Texture/Mesh/Object3d/Object3d.h
+++ b/project/Engine/Texture/Mesh/Object3d/Object3d.h
@@ -13,6 +13,7 @@
 #include <d3d12.h>
 #include <memory>
 #include <string>
+#include <vector>
 #include <wrl.h>
 class Camera;
 struct SkinCluster;
@@ -123,6 +124,7 @@ public:
 	const std::string& GetEditorId() const { return editorId_; }
 	void SetEditorRegistrationEnabled(bool enable) { editorRegistrationEnabled_ = enable; }
 	void RegisterEditor(const std::string& registrationName);
+	static void RegisterEditors(const std::vector<Object3d*>& objects, const std::string& registrationNamePrefix);
 	void RegisterToEditor();
 	void RegisterToEditor(const std::string& saveFileName, const std::string& registrationName);
 	void UnregisterFromEditor();

--- a/project/Engine/Texture/Mesh/Primitive/Primitive.cpp
+++ b/project/Engine/Texture/Mesh/Primitive/Primitive.cpp
@@ -11,6 +11,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstring>
+#include <string>
 
 namespace {
 constexpr uint32_t kDefaultSlices = 32;
@@ -620,6 +621,14 @@ void Primitive::RegisterEditor(const std::string& registrationName) {
 		Hierarchy::GetInstance()->AddRegisterPrimitive(this, registrationName);
 	}
 	RegisterToEditor();
+}
+void Primitive::RegisterEditors(const std::vector<Primitive*>& primitives, const std::string& registrationNamePrefix) {
+	for (size_t i = 0; i < primitives.size(); ++i) {
+		if (!primitives[i]) {
+			continue;
+		}
+		primitives[i]->RegisterEditor(registrationNamePrefix + std::to_string(i));
+	}
 }
 void Primitive::RegisterToEditor() {
 	if (isEditorRegistered_) {

--- a/project/Engine/Texture/Mesh/Primitive/Primitive.h
+++ b/project/Engine/Texture/Mesh/Primitive/Primitive.h
@@ -143,6 +143,7 @@ public:
 	void SetEditorId(const std::string& id) { editorId_ = id; }
 	const std::string& GetEditorId() const { return editorId_; }
 	void RegisterEditor(const std::string& registrationName);
+	static void RegisterEditors(const std::vector<Primitive*>& primitives, const std::string& registrationNamePrefix);
 	void RegisterToEditor();
 	void RegisterToEditor(const std::string& saveFileName, const std::string& registrationName);
 	void UnregisterFromEditor();

--- a/project/application/GameObject/Chair/Chair.cpp
+++ b/project/application/GameObject/Chair/Chair.cpp
@@ -82,13 +82,14 @@ void Chair::Initialize() {
     isRayHit_ = false;
     isStand_ = false;
     obj_->Initialize();
-	obj_->RegisterEditor("Chair");
     velocity_ = { 0.0f };
     transform_ = obj_->GetTransform();
     chairMoveSeTimer_ = 0.0f;
 	obj_->SetOutlineColor(kRayHitOutlineColor);
 	obj_->SetOutlineWidth(kRayHitOutlineWidth);
 }
+
+void Chair::RegisterEditor(const std::string& registrationName) { obj_->RegisterEditor(registrationName); }
 
 void Chair::Draw() {
 	if (isRayHit_) {

--- a/project/application/GameObject/Chair/Chair.h
+++ b/project/application/GameObject/Chair/Chair.h
@@ -22,9 +22,11 @@ public:
     void Draw();
     static void SetPlayerCamera(PlayerCamera* camera);
     void SetCamera(Camera* camera);
+    void RegisterEditor(const std::string& registrationName);
     void SetTransform(const Transform& transform) { transform_ = transform; };
     void SetMirrorTransform(Transform* transform) { mirrorTransform_ = transform; };
     Transform& GetTransform() { return transform_; };
+    Object3d* GetObject3d() const { return obj_.get(); }
     bool GetIsStand() { return isStand_; }
     void SetIsStand(const bool isStand) { isStand_ = isStand; }
     bool IsRayHit() { return isRayHit_; }
@@ -44,4 +46,3 @@ private:
     bool isRayHit_ = false;
 	float chairMoveSeTimer_ = 0.0f;
 };
-

--- a/project/application/GameObject/Chair/ChairManager.cpp
+++ b/project/application/GameObject/Chair/ChairManager.cpp
@@ -39,6 +39,12 @@ void ChairManager::Initialize()
     for (auto& chair : chairs_) {
         chair->Initialize();
     }
+    std::vector<Object3d*> chairObjects;
+    chairObjects.reserve(chairs_.size());
+    for (const auto& chair : chairs_) {
+        chairObjects.push_back(chair->GetObject3d());
+    }
+    Object3d::RegisterEditors(chairObjects, "Chair");
 
 
 

--- a/project/application/GameObject/Wall/Wall.cpp
+++ b/project/application/GameObject/Wall/Wall.cpp
@@ -46,8 +46,9 @@ void Wall::Update()
 void Wall::Initialize()
 {
     primitive_->Initialize(Primitive::Box, "Resources/TD3_3102/2d/wall.png");
-    primitive_->RegisterEditor("Wall");
 }
+
+void Wall::RegisterEditor(const std::string& registrationName) { primitive_->RegisterEditor(registrationName); }
 
 void Wall::Draw()
 {

--- a/project/application/GameObject/Wall/Wall.h
+++ b/project/application/GameObject/Wall/Wall.h
@@ -21,13 +21,14 @@ public:
     void Initialize();
     void Draw();
     void SetCamera(Camera* camera);
+    void RegisterEditor(const std::string& registrationName);
     void AdjustAABB();
     //親を設定する
     void SetParentMatrix(Matrix4x4* parent) { parentMat_ = parent; }
     void SetST(const Vector3& scale, const Vector3& translate);
     const Matrix4x4& GetWorldMatrix() const { return primitive_->GetWorldMatrix(); };
+    Primitive* GetPrimitive() const { return primitive_.get(); }
 private:
     Matrix4x4* parentMat_ = nullptr;
     std::unique_ptr<Primitive>primitive_ = nullptr;
 };
-

--- a/project/application/GameObject/Wall/WallManager.cpp
+++ b/project/application/GameObject/Wall/WallManager.cpp
@@ -66,6 +66,12 @@ void WallManager::Initialize()
     for (auto& wall : walls_) {
         wall->Initialize();
     }
+    std::vector<Primitive*> wallPrimitives;
+    wallPrimitives.reserve(walls_.size());
+    for (const auto& wall : walls_) {
+        wallPrimitives.push_back(wall->GetPrimitive());
+    }
+    Primitive::RegisterEditors(wallPrimitives, "Wall");
 }
 
 void WallManager::Update()


### PR DESCRIPTION
### Motivation
- Provide a way to register multiple `Object3d`/`Primitive` instances to the editor with unique indexed names to avoid duplicate registrations. 
- Move responsibility for registering repeated objects (chairs, walls) from each instance to their managers so the editor list is deterministic and non-conflicting. 
- Make it easy to register a collection of objects at once from managers instead of calling `RegisterEditor` with fixed names per instance.

### Description
- Added static helper APIs `Object3d::RegisterEditors(const std::vector<Object3d*>&, const std::string&)` and `Primitive::RegisterEditors(const std::vector<Primitive*>&, const std::string&)` that loop and call per-instance `RegisterEditor` with a prefix plus index. 
- Exposed getters on game objects (`Chair::GetObject3d()` and `Wall::GetPrimitive()`) and added small wrappers `Chair::RegisterEditor` and `Wall::RegisterEditor` so managers can collect underlying render objects. 
- Removed per-instance fixed-name registration calls in `Chair::Initialize()` and `Wall::Initialize()`, and instead register all chairs and walls in `ChairManager::Initialize()` and `WallManager::Initialize()` by gathering pointers and calling the new `RegisterEditors` helpers. 
- Minor include/implementation updates (`<vector>`, `<string>`) and added implementations in corresponding `.cpp` files.

### Testing
- Ran `git diff --check` to ensure no whitespace/patch issues and it succeeded. 
- Verified repository status with `git status --short` and changes are committed. 
- Searched for lingering hard-coded registrations with `rg "RegisterEditor\(\"Chair\"|RegisterEditor\(\"Wall\""` and confirmed no remaining per-instance fixed-name calls; the manager-level registration is in place.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e74351af50832a87d8d0c8d6d75b40)