### PR TITLE
Use vector-based editor registration for wall primitives

### DIFF
--- a/project/application/GameObject/Elevator/ElevatorRoomManager.cpp
+++ b/project/application/GameObject/Elevator/ElevatorRoomManager.cpp
@@ -51,6 +51,12 @@ void ElevatorRoomManager::Initialize()
     for (auto& wall : walls_) {
         wall->Initialize();
     }
+    std::vector<Primitive*> wallPrimitives;
+    wallPrimitives.reserve(walls_.size());
+    for (const auto& wall : walls_) {
+        wallPrimitives.push_back(wall->GetPrimitive());
+    }
+    Primitive::RegisterEditors(wallPrimitives, "ElevatorWall");
 }
 
 void ElevatorRoomManager::Update()

--- a/project/application/GameObject/Wall/WallManager2.cpp
+++ b/project/application/GameObject/Wall/WallManager2.cpp
@@ -52,6 +52,12 @@ void WallManager2::Initialize()
     for (auto& wall : walls_) {
         wall->Initialize();
     }
+    std::vector<Primitive*> wallPrimitives;
+    wallPrimitives.reserve(walls_.size());
+    for (const auto& wall : walls_) {
+        wallPrimitives.push_back(wall->GetPrimitive());
+    }
+    Primitive::RegisterEditors(wallPrimitives, "Wall2");
 }
 void WallManager2::Update()
 {


### PR DESCRIPTION
### Motivation
- walls_ 管理下の複数プリミティブを既存のベクトル指向エディタ登録フローに合わせて一括登録できるようにするため。

### Description
- project/application/GameObject/Wall/WallManager2.cpp と project/application/GameObject/Elevator/ElevatorRoomManager.cpp の `Initialize()` 内で `walls_` から `std::vector<Primitive*>` を作成し、`Primitive::RegisterEditors(wallPrimitives, "Wall2")` / `Primitive::RegisterEditors(wallPrimitives, "ElevatorWall")` を呼び出して一括登録する処理を追加しました。

### Testing
- 変更差分を確認するために `git diff` と `git status --short` を実行してパッチを検証しました; ビルドや自動テストはこの環境では実行していません。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e745c7b898832a942935d1814c4a68)