### PR TITLE
Load stage-specific object editor JSON in MirrorStage and ShadowGameScene

### DIFF
--- a/project/Engine/Editor/EditorTool/Hierarchy/Hierarchy.cpp
+++ b/project/Engine/Editor/EditorTool/Hierarchy/Hierarchy.cpp
@@ -431,14 +431,22 @@ bool Hierarchy::LoadObjectEditorsFromJsonIfExists(const std::string& filePath) {
 	}
 
 	const std::string scopedFilePath = GetSceneScopedEditorFilePath(filePath);
-	if (!HasObjectEditorJsonFile(scopedFilePath)) {
+	std::string resolvedFilePath;
+	if (HasObjectEditorJsonFile(scopedFilePath)) {
+		resolvedFilePath = scopedFilePath;
+	} else if (HasObjectEditorJsonFile(filePath)) {
+		resolvedFilePath = filePath;
+	} else {
 		return false;
 	}
-	if (hasLoadedForCurrentScene_) {
+
+	if (hasLoadedForCurrentScene_ && loadedSnapshotFilePath_ == resolvedFilePath) {
 		return true;
 	}
-	hasLoadedForCurrentScene_ = LoadObjectEditorsFromJson(scopedFilePath);
-	return hasLoadedForCurrentScene_;
+
+	const bool isLoaded = LoadObjectEditorsFromJson(resolvedFilePath);
+	hasLoadedForCurrentScene_ = hasLoadedForCurrentScene_ || isLoaded;
+	return isLoaded;
 }
 
 bool Hierarchy::SaveObjectEditorsToJson(const std::string& filePath) const {

--- a/project/application/Scene/TD3_4month/ShadowGameScene.cpp
+++ b/project/application/Scene/TD3_4month/ShadowGameScene.cpp
@@ -63,7 +63,6 @@ ShadowGameScene::ShadowGameScene() {
 	SetPlayerCamera(cameraController_->GetPlayerCamera());
 
 	damageOverlay_ = std::make_unique<DamageOverlay>();
-	Hierarchy::GetInstance()->LoadObjectEditorsFromJsonIfExists("objectEditors.json");
 }
 
 ShadowGameScene::~ShadowGameScene()
@@ -116,6 +115,7 @@ void ShadowGameScene::Initialize()
 	elevatorRoomManager_->Initialize();
 	// エレベーター
 	elevator_->Initialize();
+	hierarchy->LoadObjectEditorsFromJsonIfExists("ShadowGameScene_objectEditors.json");
 	hierarchy->EndRegisterFile();
 	stageManager_->SetPlayerCamera(cameraController_->GetPlayerCamera());
 	stageManager_->SetLightManager(lightManager_.get());

--- a/project/application/Stages/Stage/MirrorStage.cpp
+++ b/project/application/Stages/Stage/MirrorStage.cpp
@@ -76,6 +76,7 @@ void MirrorStage::Initialize() {
 	timeCardRack_->Initialize();
 	boxManager_->Initialize();
 	InitializeLights();
+	hierarchy->LoadObjectEditorsFromJsonIfExists("MirrorStage_objectEditors.json");
 	hierarchy->EndRegisterFile();
 
 }


### PR DESCRIPTION
### Motivation
- Ensure object/editor JSON saved for a scene or stage is applied to actual objects/primitives when that scene/stage is initialized.  
- Fix incorrect timing where ShadowGameScene attempted to load editor JSON in the constructor before registrations happened.  
- Prefer scene-scoped JSON but allow falling back to the provided file name and permit loading additional editor JSON files per scene.  

### Description
- Updated `Hierarchy::LoadObjectEditorsFromJsonIfExists` to prefer the scene-scoped editor JSON (`SceneName_file.json`) and fall back to the exact `filePath` when the scoped file doesn't exist, and to allow subsequent loads for different editor files in the same scene by checking the resolved path against `loadedSnapshotFilePath_`.  
- Added `hierarchy->LoadObjectEditorsFromJsonIfExists("MirrorStage_objectEditors.json")` to `MirrorStage::Initialize` so MirrorStage loads its editor JSON after objects/primitives are registered and initialized.  
- Moved the Shadow scene JSON load out of the `ShadowGameScene` constructor and into `ShadowGameScene::Initialize`, calling `hierarchy->LoadObjectEditorsFromJsonIfExists("ShadowGameScene_objectEditors.json")` after registrations and initialization.  
- Modified files: `project/Engine/Editor/EditorTool/Hierarchy/Hierarchy.cpp`, `project/application/Stages/Stage/MirrorStage.cpp`, and `project/application/Scene/TD3_4month/ShadowGameScene.cpp`.

### Testing
- No automated tests were available or executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9055086d0832a9c30d50e0ea9d09a)