### PR TITLE
Prevent wall transforms from being overwritten each frame

### DIFF
--- a/project/application/GameObject/Wall/WallManager.cpp
+++ b/project/application/GameObject/Wall/WallManager.cpp
@@ -71,13 +71,19 @@ void WallManager::Initialize()
     for (const auto& wall : walls_) {
         wallPrimitives.push_back(wall->GetPrimitive());
     }
+
+    const float offsetX = 100.0f;
+    const float offsetZ = 100.0f;
+    walls_[0]->SetST({ 2.0f,4.0f,14.0f }, { -7.0f + offsetX ,0.0f,2.0f + offsetZ });
+    walls_[1]->SetST({ 2.0f,4.0f,14.0f }, { 7.0f + offsetX  ,0.0f,2.0f + offsetZ });
+    walls_[2]->SetST({ 14.0f,4.0f,1.0f }, { 2.0f + offsetZ,0.0f,-7.0f + offsetX });
+    walls_[3]->SetST({ 14.0f,4.0f,1.0f }, { 2.0f + offsetZ,0.0f, 7.0f + offsetX });
+
     /*Primitive::RegisterEditors(wallPrimitives, "Wall");*/
 }
 
 void WallManager::Update()
 {
-	float offsetX = 100.0f;
-	float offsetZ = 100.0f;
     plane_->SetEnableLighting(false);
     room1_->Update();
     room1_->SetEnableLighting(true);
@@ -93,11 +99,6 @@ void WallManager::Update()
 
     areaLights_[1].height = plane_->GetTransform().scale.y * 0.5f;
 
-    walls_[0]->SetST({ 2.0f,4.0f,14.0f }, { -7.0f+offsetX ,0.0f,2.0f+offsetZ });
-    walls_[1]->SetST({ 2.0f,4.0f,14.0f }, { 7.0f+offsetX  ,0.0f,2.0f+offsetZ});
-
-    walls_[2]->SetST({ 14.0f,4.0f,1.0f }, {2.0f+offsetZ,0.0f,-7.0f+offsetX });
-    walls_[3]->SetST({ 14.0f,4.0f,1.0f }, {2.0f+offsetZ,0.0f, 7.0f+offsetX });
     for (auto& wall : walls_) {
         wall->Update();
     }

--- a/project/application/GameObject/Wall/WallManager2.cpp
+++ b/project/application/GameObject/Wall/WallManager2.cpp
@@ -57,12 +57,20 @@ void WallManager2::Initialize()
     for (const auto& wall : walls_) {
         wallPrimitives.push_back(wall->GetPrimitive());
     }
+
+    const float offsetX = 100.0f;
+    const float offsetZ = 7.0f;
+    Vector3 translate = { 7.0f,0.0f,0.0f };
+    walls_[0]->SetST({ 2.0f,4.0f,14.0f }, translate + Vector3{ 7.0f + offsetX,2.0f,0.0f + offsetZ });
+    walls_[1]->SetST({ 2.0f,4.0f,14.0f }, translate + Vector3{ -7.0f + offsetX,2.0f,0.0f + offsetZ });
+    walls_[2]->SetST({ 14.0f,4.0f,1.0f }, translate + Vector3{ 0.0f + offsetX,2.0f,7.0f + offsetZ });
+    walls_[3]->SetST({ 7.0f, 4.0f,1.0f, }, translate + Vector3{ -3.75f + offsetX,2.0f,-6.5f + offsetZ });
+    walls_[4]->SetST({ 7.0f, 4.0f,1.0f, }, translate + Vector3{ 3.75f + offsetX,2.0f ,-6.5f + offsetZ });
+
     /*Primitive::RegisterEditors(wallPrimitives, "Wall2:");*/
 }
 void WallManager2::Update()
 {
-	float offsetX = 100.0f;
-	float offsetZ = 7.0f;
     plane_->SetEnableLighting(false);
     room1_->Update();
     //roomMat_ = room1_->GetWorldMatrix();
@@ -74,16 +82,6 @@ void WallManager2::Update()
     areaLights_[1].normal = normal;
     areaLights_[1].position = YoshidaMath::GetWorldPosByMat(plane_->GetWorldMatrix()) - normal * 2.0f;
     areaLights_[1].height = plane_->GetTransform().scale.y*0.5f;
-    Vector3 translate = {7.0f,0.0f,0.0f};
-
-    walls_[0]->SetST({ 2.0f,4.0f,14.0f }, translate+Vector3{ 7.0f+offsetX,2.0f,0.0f+offsetZ });
-    walls_[1]->SetST({ 2.0f,4.0f,14.0f }, translate+Vector3{ -7.0f+offsetX,2.0f,0.0f+offsetZ});
-    //裏側                  
-    walls_[2]->SetST({ 14.0f,4.0f,1.0f }, translate+Vector3{ 0.0f+offsetX,2.0f,7.0f+offsetZ });
-                                  
-    walls_[3]->SetST({7.0f, 4.0f,1.0f,}, translate+Vector3{ -3.75f+offsetX,2.0f,-6.5f+offsetZ });
-    walls_[4]->SetST({7.0f, 4.0f,1.0f,}, translate+Vector3{ 3.75f+offsetX,2.0f ,-6.5f+offsetZ });
-   
     for (auto& wall : walls_) {
         wall->Update();
     }


### PR DESCRIPTION
### Motivation
- Wall `translate` edits made at runtime or in the editor had no effect because hard-coded `SetST` calls in `Update()` were reapplying fixed transforms every frame.
- The intent is to apply default wall transforms once at initialization so subsequent adjustments persist.

### Description
- Moved default `walls_[i]->SetST(...)` calls out of `Update()` and into `Initialize()` in `WallManager` and `WallManager2`.
- Added local `offsetX`/`offsetZ` and `translate` values in `Initialize()` to reproduce the previous placement logic while avoiding per-frame overwrites.
- Removed the per-frame hard-coded `SetST` calls from both `Update()` implementations so wall transforms are no longer reset each frame.
- Changes affect `project/application/GameObject/Wall/WallManager.cpp` and `project/application/GameObject/Wall/WallManager2.cpp`.

### Testing
- Ran `git diff --check` and observed no whitespace or patch errors.
- Verified modified file status with `git status --short` to confirm the intended files were changed.
- Created a commit for the change to record the fix (`git commit` succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e912092128832a91885f03b5f6dcb6)