### PR TITLE
Register WallManager room models with editor

### DIFF
--- a/project/application/GameObject/Wall/WallManager.cpp
+++ b/project/application/GameObject/Wall/WallManager.cpp
@@ -58,6 +58,7 @@ WallManager::~WallManager()
 void WallManager::Initialize()
 {
     room1_->Initialize();
+    room1_->RegisterEditor("room1");
     plane_->Initialize(Primitive::Plane, "Resources/TD3_3102/2d/out.jpg");
     plane_->RegisterEditor("WallWindowPlane");
 

--- a/project/application/GameObject/Wall/WallManager2.cpp
+++ b/project/application/GameObject/Wall/WallManager2.cpp
@@ -45,6 +45,7 @@ WallManager2::WallManager2()
 void WallManager2::Initialize()
 {
     room1_->Initialize();
+    room1_->RegisterEditor("room2");
     plane_->Initialize(Primitive::Plane, "Resources/TD3_3102/2d/out.jpg");
     plane_->RegisterEditor("Wall2WindowPlane");
 


### PR DESCRIPTION
### Motivation
- Expose the room objects managed by WallManager/WallManager2 to the in-engine editor so they appear in the editor hierarchy and can be edited, matching other room managers.

### Description
- Add editor registration for the room objects by calling `room1_->RegisterEditor("room1");` in `project/application/GameObject/Wall/WallManager.cpp` and `room1_->RegisterEditor("room2");` in `project/application/GameObject/Wall/WallManager2.cpp` inside their `Initialize()` methods.

### Testing
- Ran repository checks (`git status --short`) and inspected the modified files with `nl -ba ... | sed -n ...` and committed the changes with `git commit`, and these commands succeeded; no automated unit/integration tests were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e93a730c14832a8b3a56a568c29155)