### PR TITLE
Fix editor value loading for WhiteBoard and Desk

### DIFF
--- a/project/application/GameObject/Desk/Desk.cpp
+++ b/project/application/GameObject/Desk/Desk.cpp
@@ -85,7 +85,7 @@ void Desk::Update()
 void Desk::Initialize()
 {
     obj_->Initialize();
-	obj_->RegisterEditor("Desk");
+	obj_->RegisterEditor(animationGroupName_);
     isRayHit_ = false;
     desiredAnimationName = "Idle";
 

--- a/project/application/GameObject/WhiteBoard/WhiteBoard.cpp
+++ b/project/application/GameObject/WhiteBoard/WhiteBoard.cpp
@@ -23,7 +23,7 @@ Vector3 WhiteBoard::GetWorldPosition() const
 void WhiteBoard::Initialize()
 {
     obj_->Initialize();
-	obj_->RegisterEditor("WhiteBoard");
+	obj_->RegisterEditor(editorRegistrationName_);
     obj_->SetRotate({ 0.0f,Function::kPi,0.0f });
 #ifdef _DEBUG
     primitive_->Initialize(Primitive::Box);

--- a/project/application/GameObject/WhiteBoard/WhiteBoard.h
+++ b/project/application/GameObject/WhiteBoard/WhiteBoard.h
@@ -4,6 +4,7 @@
 #include"RigidBody.h"
 #include"Primitive/Primitive.h"
 #include"GameObject/YoshidaMath/CollisionManager/Collider.h"
+#include <string>
 
 class WhiteBoard  : public YoshidaMath::Collider
 {
@@ -19,6 +20,7 @@ public:
     virtual void Draw();
     void SetCamera(Camera* camera);
     void SetModel(const std::string& filePath);
+    void SetEditorRegistrationName(const std::string& name) { editorRegistrationName_ = name; }
     AABB GetAABB();
     Transform& GetCollisionTransform() { return collisionTransform_; }
     virtual void ResetCollisionAttribute();
@@ -35,4 +37,5 @@ protected:
     Transform collisionTransform_ = {};
 private:
     const float kPortalCreatableAngleRange_ = 0.5f;
+    std::string editorRegistrationName_ = "WhiteBoard";
 };

--- a/project/application/GameObject/WhiteBoard/WhiteBoardManager.cpp
+++ b/project/application/GameObject/WhiteBoard/WhiteBoardManager.cpp
@@ -5,6 +5,7 @@
 #include "GameObject/SEManager/SEManager.h"
 #include "GameObject/WhiteBoard/WalkWhiteBoard.h"
 #include "Model/ModelManager.h"
+#include <string>
 
 
 namespace {
@@ -19,12 +20,14 @@ WhiteBoardManager::WhiteBoardManager(Vector3* playerPos) {
     std::unique_ptr<WalkWhiteBoard> walkWhite = std::make_unique<WalkWhiteBoard>();
     WalkWhiteBoard::LoadAnimation("Resources/TD3_3102/3d/whiteBoard", "whiteBoard");
     walkWhite->SetModel("whiteBoard");
+    walkWhite->SetEditorRegistrationName("WalkWhiteBoard");
     walkWhite->SetTargetPosPtr(playerPos_);
     whiteBoards_.push_back(std::move(walkWhite));
 
     for (int i = 0; i < kMaxWhiteBoards; ++i) {
         std::unique_ptr<WhiteBoard> white = std::make_unique<WhiteBoard>();
         white->SetModel("whiteBoard");
+        white->SetEditorRegistrationName("WhiteBoard" + std::to_string(i));
         whiteBoards_.push_back(std::move(white));
     }
 }


### PR DESCRIPTION
### Motivation
- Editor values were not applied correctly because multiple in-game objects shared the same editor registration name, causing JSON-to-object mapping to be ambiguous.
- The change aims to make editor registration names unique per object so the editor value loader can map saved transforms/materials to the correct instance.

### Description
- `Desk::Initialize` now calls `obj_->RegisterEditor(animationGroupName_)` so each desk instance registers with its unique `animationGroupName_` instead of the hardcoded "Desk".
- `WhiteBoard` gains an `editorRegistrationName_` member and a `SetEditorRegistrationName` setter, and uses that name when registering with the editor in `Initialize`.
- `WhiteBoardManager` assigns distinct registration names: `WalkWhiteBoard` for the movable board and `WhiteBoard0..WhiteBoardN` for the static boards, ensuring one-to-one mapping for editor JSON loading.
- Added necessary `#include <string>` where needed to support string operations.

### Testing
- Repository status was checked to confirm a clean working tree after the changes and the modifications were committed successfully (status check passed).
- No automated build or runtime tests were executed in this environment, so compilation and runtime behavior were not validated here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9548d5f98832a9973505ba7a5649c)