### PR TITLE
Add OperationChangeBox-driven radicon operation mode with fixed camera and room

### DIFF
--- a/project/application/GameObject/GameCamera/PlayerCamera/PlayerCamera.cpp
+++ b/project/application/GameObject/GameCamera/PlayerCamera/PlayerCamera.cpp
@@ -22,8 +22,8 @@ PlayerCamera::PlayerCamera() {
 }
 
 void PlayerCamera::Update() {
-    SetRay();
     SetHeadTransform();
+    SetRay();
     camera_->Update();
 }
 
@@ -77,6 +77,11 @@ bool PlayerCamera::OnCollisionRay(const AABB& localAABB, const Vector3& translat
 
 void PlayerCamera::SetHeadTransform()
 {
+    if (isFixedTransformEnabled_) {
+        param_.transform = fixedTransform_;
+        camera_->SetTransform(param_.transform);
+        return;
+    }
 
     Rotate();
     param_.transform.scale = { 1.0f,1.0f,1.0f };
@@ -108,9 +113,17 @@ void PlayerCamera::SetTransform()
     camera_->SetTransform(param_.transform);
 }
 
+void PlayerCamera::EnableFixedTransform(const Transform& transform) {
+    isFixedTransformEnabled_ = true;
+    fixedTransform_ = transform;
+    param_.transform = fixedTransform_;
+    camera_->SetTransform(param_.transform);
+}
+
+void PlayerCamera::DisableFixedTransform() { isFixedTransformEnabled_ = false; }
+
 Vector3 PlayerCamera::GetForward()
 {
     return  YoshidaMath::GetForward(camera_->GetWorldMatrix());
 }
-
 

--- a/project/application/GameObject/GameCamera/PlayerCamera/PlayerCamera.h
+++ b/project/application/GameObject/GameCamera/PlayerCamera/PlayerCamera.h
@@ -25,6 +25,9 @@ public:
     void SetPlayer(Player* player) { player_ = player; }
     void SetHeadTransform();
     void SetTransform();
+    void EnableFixedTransform(const Transform& transform);
+    void DisableFixedTransform();
+    bool IsFixedTransformEnabled() const { return isFixedTransformEnabled_; }
 
 private:
     //回転
@@ -41,5 +44,6 @@ private:
     //カメラの設定
     std::unique_ptr<Camera> camera_ = nullptr;
     Player* player_ = nullptr;
+    bool isFixedTransformEnabled_ = false;
+    Transform fixedTransform_{};
 };
-

--- a/project/application/GameObject/OperationChangeBox/OperationChangeBox.cpp
+++ b/project/application/GameObject/OperationChangeBox/OperationChangeBox.cpp
@@ -1,1 +1,75 @@
 #include "OperationChangeBox.h"
+#include "Engine/math/Function.h"
+#include "GameObject/GameCamera/PlayerCamera/PlayerCamera.h"
+#include "GameObject/KeyBindConfig.h"
+#include "Primitive/Primitive.h"
+
+namespace {
+constexpr Vector4 kRayHitColor = {1.0f, 0.95f, 0.5f, 1.0f};
+constexpr Vector4 kDefaultColor = {0.75f, 0.9f, 1.0f, 1.0f};
+}
+
+void OperationChangeBox::Initialize() {
+    box_ = std::make_unique<Primitive>();
+    box_->Initialize(Primitive::Box, "Resources/TD3_3102/2d/white.png");
+    transform_ = {
+        .scale = {0.9f, 0.75f, 0.9f},
+        .rotate = {0.0f, Function::kPi, 0.0f},
+        .translate = {0.0f, 0.75f, -3.0f},
+    };
+    box_->SetTransform(transform_);
+    box_->SetEnableLighting(true);
+    box_->SetColor(kDefaultColor);
+}
+
+void OperationChangeBox::Update() {
+    if (!box_) {
+        return;
+    }
+
+    isRayHit_ = OnCollisionRay();
+    if (isRayHit_ && PlayerCommand::GetInstance()->InteractTrigger()) {
+        interactRequested_ = true;
+    }
+
+    box_->SetTransform(transform_);
+    box_->SetColor(isRayHit_ ? kRayHitColor : kDefaultColor);
+    box_->Update();
+}
+
+void OperationChangeBox::Draw() {
+    if (box_) {
+        box_->Draw();
+    }
+}
+
+void OperationChangeBox::SetCamera(Camera* camera) {
+    if (!box_) {
+        return;
+    }
+
+    box_->SetCamera(camera);
+    box_->UpdateCameraMatrices();
+}
+
+bool OperationChangeBox::ConsumeInteractRequest() {
+    const bool requested = interactRequested_;
+    interactRequested_ = false;
+    return requested;
+}
+
+Vector3 OperationChangeBox::GetForward() const { return Function::MakeForwardFromRotate(transform_.rotate); }
+
+AABB OperationChangeBox::GetAABB() const {
+    return {
+        .min = {-transform_.scale.x * 0.5f, -transform_.scale.y * 0.5f, -transform_.scale.z * 0.5f},
+        .max = {transform_.scale.x * 0.5f, transform_.scale.y * 0.5f, transform_.scale.z * 0.5f},
+    };
+}
+
+bool OperationChangeBox::OnCollisionRay() const {
+    if (!playerCamera_) {
+        return false;
+    }
+    return playerCamera_->OnCollisionRay(GetAABB(), transform_.translate);
+}

--- a/project/application/GameObject/OperationChangeBox/OperationChangeBox.h
+++ b/project/application/GameObject/OperationChangeBox/OperationChangeBox.h
@@ -1,2 +1,33 @@
 #pragma once
-class OperationChangeBox {};
+#include "GameObject/YoshidaMath/CollisionManager/Collider.h"
+#include "Transform.h"
+#include <memory>
+
+class Camera;
+class PlayerCamera;
+class Primitive;
+
+class OperationChangeBox {
+public:
+    void Initialize();
+    void Update();
+    void Draw();
+    void SetCamera(Camera* camera);
+    void SetPlayerCamera(PlayerCamera* playerCamera) { playerCamera_ = playerCamera; }
+
+    bool ConsumeInteractRequest();
+    bool IsRayHit() const { return isRayHit_; }
+    const Transform& GetTransform() const { return transform_; }
+    Vector3 GetForward() const;
+
+private:
+    AABB GetAABB() const;
+    bool OnCollisionRay() const;
+
+private:
+    std::unique_ptr<Primitive> box_ = nullptr;
+    PlayerCamera* playerCamera_ = nullptr;
+    Transform transform_{};
+    bool isRayHit_ = false;
+    bool interactRequested_ = false;
+};

--- a/project/application/GameObject/Radicon/Radicon.cpp
+++ b/project/application/GameObject/Radicon/Radicon.cpp
@@ -2,21 +2,45 @@
 #include "Model/ModelManager.h"
 #include "Engine/math/Function.h"
 #include "Engine/Texture/Mesh/Object3d/Object3dCommon.h"
+#include "GameObject/KeyBindConfig.h"
 void Radicon::Initialize() {
 	obj_ = std::make_unique<Object3d>();
 	ModelManager::GetInstance()->LoadGltfModel("Resources/TD3_3102/3d/radicon", "Radicon");
 	obj_->SetModel("Radicon");
 	obj_->SetScale({ 0.01f, 0.01f, 0.01f });
-	speed_ = 0.1f;
-	transform_ = obj_->GetTransform();
+	transform_ = {
+		.scale = {0.01f, 0.01f, 0.01f},
+		.rotate = {0.0f, 0.0f, 0.0f},
+		.translate = {0.0f, 0.17f, 4.0f},
+	};
+	speed_ = 0.06f;
+	obj_->SetTransform(transform_);
 }
 void Radicon::SetCamera(Camera* camera) {
 	obj_->SetCamera(camera); }
-void Radicon::Update() {
-	velocity_.x += speed_ * Function::MakeForwardFromRotate(transform_.rotate).x;
-	velocity_.z += speed_ * Function::MakeForwardFromRotate(transform_.rotate).z;
-	transform_.translate.x += velocity_.x;
-	transform_.translate.z += velocity_.z;
+void Radicon::Update(bool isOperationMode) {
+	velocity_ = {0.0f, 0.0f, 0.0f};
+	if (isOperationMode) {
+		if (PlayerCommand::GetInstance()->MoveLeft()) {
+			transform_.rotate.y -= 0.03f;
+		}
+		if (PlayerCommand::GetInstance()->MoveRight()) {
+			transform_.rotate.y += 0.03f;
+		}
+
+		float throttle = 0.0f;
+		if (PlayerCommand::GetInstance()->MoveForward()) {
+			throttle += 1.0f;
+		}
+		if (PlayerCommand::GetInstance()->MoveBackward()) {
+			throttle -= 1.0f;
+		}
+		velocity_ = Function::MakeForwardFromRotate(transform_.rotate) * (throttle * speed_);
+		transform_.translate += velocity_;
+	}
+
+	transform_.translate.y = 0.17f;
+	obj_->SetTransform(transform_);
 	obj_->SetTranslate(transform_.translate);
 	obj_->Update();
 }

--- a/project/application/GameObject/Radicon/Radicon.h
+++ b/project/application/GameObject/Radicon/Radicon.h
@@ -13,8 +13,10 @@ class Radicon {
 
 	void Initialize();
 	void SetCamera(Camera* camera);
-	void Update();
+	void Update(bool isOperationMode);
 	void Draw();
+	void SetTransform(const Transform& transform) { transform_ = transform; }
+	const Transform& GetTransform() const { return transform_; }
 	
 
 };

--- a/project/application/Scene/TD3_4month/ShadowGameScene.cpp
+++ b/project/application/Scene/TD3_4month/ShadowGameScene.cpp
@@ -207,8 +207,15 @@ void ShadowGameScene::Finalize()
 void ShadowGameScene::DebugImGui() {
 #ifdef USE_IMGUI
 	ImGui::Begin("shadowGameScene");
-	static constexpr const char* kStageNames[] = {"MirrorStage", "LightStage", "TutorialStage"};
-	int stageIndex = (progressSaveData_.currentStageName == "LightStage") ? 1 : (progressSaveData_.currentStageName == "TutorialStage") ? 2 : 0;
+	static constexpr const char* kStageNames[] = {"MirrorStage", "LightStage", "TutorialStage", "RadiconStage"};
+	int stageIndex = 0;
+	if (progressSaveData_.currentStageName == "LightStage") {
+		stageIndex = 1;
+	} else if (progressSaveData_.currentStageName == "TutorialStage") {
+		stageIndex = 2;
+	} else if (progressSaveData_.currentStageName == "RadiconStage") {
+		stageIndex = 3;
+	}
 	if (ImGui::Combo("Stage", &stageIndex, kStageNames, IM_ARRAYSIZE(kStageNames))) {
 		ChangeStage(kStageNames[stageIndex]);
 	}

--- a/project/application/Stages/Stage/RadiconStage.cpp
+++ b/project/application/Stages/Stage/RadiconStage.cpp
@@ -1,15 +1,41 @@
 #include "RadiconStage.h"
+#include "Engine/math/Function.h"
 #include "GameObject/YoshidaMath/CollisionManager/CollisionManager.h"
 #include "GameObject/GameCamera/PlayerCamera/PlayerCamera.h"
 #include "Engine/Editor/EditorTool/Hierarchy/Hierarchy.h"
+#include "Primitive/Primitive.h"
+#include <cmath>
 
 RadiconStage::RadiconStage(Player* player) : player_(player) {
 	radicon_ = std::make_unique<Radicon>();
+	testField_ = std::make_unique<TestField>();
+	operationChangeBox_ = std::make_unique<OperationChangeBox>();
 }
 
 void RadiconStage::Initialize() { 
 	Hierarchy::GetInstance()->BeginRegisterFile("RadiconStage_objectEditors.json");
+	testField_->Initialize();
 	radicon_->Initialize();
+	operationChangeBox_->Initialize();
+	radicon_->SetTransform({
+	    .scale = {0.01f, 0.01f, 0.01f},
+	    .rotate = {0.0f, Function::kPi, 0.0f},
+	    .translate = {0.0f, 0.17f, 3.5f},
+	});
+
+	for (auto& primitive : roomPrimitives_) {
+		primitive = std::make_unique<Primitive>();
+		primitive->Initialize(Primitive::Box, "Resources/TD3_3102/2d/white.png");
+		primitive->SetEnableLighting(true);
+		primitive->SetColor({0.9f, 0.9f, 0.95f, 1.0f});
+	}
+
+	roomPrimitives_[0]->SetTransform({.scale = {12.0f, 0.2f, 12.0f}, .rotate = {0.0f}, .translate = {0.0f, -0.11f, 0.0f}});
+	roomPrimitives_[1]->SetTransform({.scale = {12.0f, 4.0f, 0.2f}, .rotate = {0.0f}, .translate = {0.0f, 2.0f, -6.0f}});
+	roomPrimitives_[2]->SetTransform({.scale = {12.0f, 4.0f, 0.2f}, .rotate = {0.0f}, .translate = {0.0f, 2.0f, 6.0f}});
+	roomPrimitives_[3]->SetTransform({.scale = {0.2f, 4.0f, 12.0f}, .rotate = {0.0f}, .translate = {-6.0f, 2.0f, 0.0f}});
+	roomPrimitives_[4]->SetTransform({.scale = {0.2f, 4.0f, 12.0f}, .rotate = {0.0f}, .translate = {6.0f, 2.0f, 0.0f}});
+
 	Hierarchy::GetInstance()->EndRegisterFile();
 }
 
@@ -21,18 +47,61 @@ void RadiconStage::SetCollisionManager([[maybe_unused]] CollisionManager* collis
 }
 
 void RadiconStage::UpdateGameObject([[maybe_unused]] Camera* camera, [[maybe_unused]] const Vector3& lightDirection, [[maybe_unused]] Player* player) { 
-	radicon_->Update(); 
+	testField_->Update();
+	operationChangeBox_->Update();
+
+	if (!isOperationMode_ && operationChangeBox_->ConsumeInteractRequest() && playerCamera_ && player_) {
+		isOperationMode_ = true;
+		lockedPlayerPosition_ = player_->GetTransform().translate;
+
+		const Vector3 forward = operationChangeBox_->GetForward();
+		Transform operationCameraTransform{};
+		operationCameraTransform.scale = {1.0f, 1.0f, 1.0f};
+		operationCameraTransform.translate = operationChangeBox_->GetTransform().translate - forward * 1.7f + Vector3{0.0f, 0.65f, 0.0f};
+		operationCameraTransform.rotate.x = 0.17f;
+		operationCameraTransform.rotate.y = std::atan2(forward.x, forward.z);
+		operationCameraTransform.rotate.z = 0.0f;
+		playerCamera_->EnableFixedTransform(operationCameraTransform);
+	}
+
+	if (isOperationMode_ && player_) {
+		player_->SetTranslate(lockedPlayerPosition_);
+	}
+
+	radicon_->Update(isOperationMode_);
+	for (auto& primitive : roomPrimitives_) {
+		primitive->Update();
+	}
 }
 
 void RadiconStage::UpdatePortal() {/*記載なし*/}
 
 void RadiconStage::CheckCollision() {}
 
-void RadiconStage::DrawModel([[maybe_unused]] bool isShadow, [[maybe_unused]] bool drawPortal, [[maybe_unused]] bool isDrawParticle) {}
+void RadiconStage::DrawModel([[maybe_unused]] bool isShadow, [[maybe_unused]] bool drawPortal, [[maybe_unused]] bool isDrawParticle) {
+	testField_->Draw();
+	for (auto& primitive : roomPrimitives_) {
+		primitive->Draw();
+	}
+	operationChangeBox_->Draw();
+	radicon_->Draw();
+}
 
-void RadiconStage::SetSceneCameraForDraw([[maybe_unused]] Camera* camera) {}
+void RadiconStage::SetSceneCameraForDraw([[maybe_unused]] Camera* camera) {
+	testField_->SetCamera(camera);
+	radicon_->SetCamera(camera);
+	operationChangeBox_->SetCamera(camera);
+	for (auto& primitive : roomPrimitives_) {
+		primitive->SetCamera(camera);
+		primitive->UpdateCameraMatrices();
+	}
+}
 
-void RadiconStage::SetPlayerCamera([[maybe_unused]] PlayerCamera* playerCamera) { radicon_->SetCamera(playerCamera->GetCamera()); }
+void RadiconStage::SetPlayerCamera([[maybe_unused]] PlayerCamera* playerCamera) {
+	playerCamera_ = playerCamera;
+	radicon_->SetCamera(playerCamera->GetCamera());
+	operationChangeBox_->SetPlayerCamera(playerCamera);
+}
 
 PortalManager* RadiconStage::GetPortalManager() { return nullptr; }
 

--- a/project/application/Stages/Stage/RadiconStage.h
+++ b/project/application/Stages/Stage/RadiconStage.h
@@ -6,6 +6,10 @@
 #include "GameObject/BurningObject/BurningObject.h"
 #include "GameObject/YoshidaMath/CollisionManager/CollisionManager.h"
 #include "GameObject/TestField/TestField.h"
+#include "GameObject/OperationChangeBox/OperationChangeBox.h"
+#include <array>
+
+class Primitive;
 class RadiconStage : public BaseStage {
 public:
 	explicit RadiconStage(Player* player);
@@ -31,4 +35,10 @@ private:
 	std::unique_ptr<Enemy> enemy_;
 	std::unique_ptr<BurningObject> burningObject_;
 	std::unique_ptr<TestField> testField_;
+	std::unique_ptr<OperationChangeBox> operationChangeBox_;
+	std::array<std::unique_ptr<Primitive>, 5> roomPrimitives_{};
+
+	PlayerCamera* playerCamera_ = nullptr;
+	bool isOperationMode_ = false;
+	Vector3 lockedPlayerPosition_{};
 };

--- a/project/application/Stages/StageManager.cpp
+++ b/project/application/Stages/StageManager.cpp
@@ -1,5 +1,6 @@
 #include "Stage/LightStage.h"
 #include "Stage/MirrorStage.h"
+#include "Stage/RadiconStage.h"
 #include "StageManager.h"
 #include"Stage/TutorialStage/TutorialStage.h"
 
@@ -16,6 +17,8 @@ void StageManager::CreateStage(const std::string& sceneName) {
         stage_ = std::make_unique<LightStage>(player_);
     } else if (sceneName == "TutorialStage") {
         stage_ = std::make_unique<TutorialStage>(player_);
+    } else if (sceneName == "RadiconStage") {
+        stage_ = std::make_unique<RadiconStage>(player_);
     }
 }
 void StageManager::SetPlayer(Player* player) {


### PR DESCRIPTION
### Motivation
- Provide an interactable switch (operation change box) so the player can enter a radio-controlled vehicle operation mode when the camera ray targets the box and the player interacts. 
- When interacting, lock the player in place and move the camera to a fixed viewpoint in front of the box so the player can control the radicon remotely. 
- Keep radicon control distinct from normal behavior so movement inputs are applied only while in operation mode. 
- Provide a minimal room (floor + surrounding walls) for the radicon operation area.

### Description
- Implemented `OperationChangeBox` as a real game object with ray-hit detection, `ConsumeInteractRequest()`, visual highlight colors, camera assignment and primitive-based rendering (files: `OperationChangeBox.h/cpp`).
- Added fixed-transform support to `PlayerCamera` via `EnableFixedTransform()` / `DisableFixedTransform()` and a guard in `SetHeadTransform()` to allow locking the camera to a provided `Transform`.
- Updated `Radicon` to accept `Update(bool isOperationMode)` and apply player movement inputs (left/right turns and forward/back throttle) only when `isOperationMode` is true, plus small initial transform/speed adjustments.
- Extended `RadiconStage` to create/initialize the `OperationChangeBox`, set up simple room primitives, detect/interact to enter operation mode, fix the `PlayerCamera` to a position in front of the box, lock the player world position while operating, and route `radicon_->Update(isOperationMode_)` and drawing/setup for the new objects.

### Testing
- Ran `git diff --check` to verify no patch formatting issues and the check passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e96ef46fd0832aa9c81f4417f2fbb7)