### PR TITLE
Fix null dereference when setting Radicon camera before initialization

### DIFF
--- a/project/application/GameObject/Radicon/Radicon.cpp
+++ b/project/application/GameObject/Radicon/Radicon.cpp
@@ -15,9 +15,14 @@ void Radicon::Initialize() {
 	};
 	speed_ = 0.06f;
 	obj_->SetTransform(transform_);
+	obj_->SetCamera(camera_);
 }
 void Radicon::SetCamera(Camera* camera) {
-	obj_->SetCamera(camera); }
+	camera_ = camera;
+	if (obj_) {
+		obj_->SetCamera(camera);
+	}
+}
 void Radicon::Update(bool isOperationMode) {
 	velocity_ = {0.0f, 0.0f, 0.0f};
 	if (isOperationMode) {

--- a/project/application/GameObject/Radicon/Radicon.h
+++ b/project/application/GameObject/Radicon/Radicon.h
@@ -5,6 +5,7 @@ class Camera;
 class Radicon {
 
 	std::unique_ptr<Object3d> obj_;
+	Camera* camera_ = nullptr;
 	Transform transform_;
 	Vector3 velocity_;
 	float speed_;


### PR DESCRIPTION
### Motivation
- Prevent a crash when `Radicon::SetCamera` is called before `Radicon::Initialize` creates the internal `Object3d`, which can happen from stage setup code.

### Description
- Added a cached `Camera* camera_` member to `Radicon`, updated `SetCamera` to store the camera and only call `obj_->SetCamera` when `obj_` exists, and applied the cached camera in `Radicon::Initialize` (changes in `project/application/GameObject/Radicon/Radicon.h` and `Radicon.cpp`).

### Testing
- Ran repository checks (`git diff` and `git commit`) for the modified files and the commands completed successfully; no automated unit tests were executed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e975aa07e4832abbafaf07cb08db55)